### PR TITLE
Fix: Preserve GET parameters in API calls

### DIFF
--- a/freemius/Freemius.php
+++ b/freemius/Freemius.php
@@ -251,6 +251,9 @@
                     }
 
                     $opts[CURLOPT_RETURNTRANSFER] = true;
+                } else if ( 'GET' === $pMethod && ! empty( $pParams ) ) {
+                    $query_string   = http_build_query( $pParams );
+                    $pCanonizedPath .= ( strpos( $pCanonizedPath, '?' ) === false ? '?' : '&' ) . $query_string;
                 }
 
                 $opts[CURLOPT_HTTPHEADER][] = "Content-Type: $content_type";

--- a/get-license-data-test.php
+++ b/get-license-data-test.php
@@ -1,0 +1,34 @@
+<?php
+
+define('FS_API__ADDRESS', 'http://api.freemius-local.com:8080');
+
+
+require_once 'freemius/FreemiusBase.php';
+require_once 'freemius/Freemius.php';
+
+define( 'FS__API_SCOPE', 'plugin' );
+define( 'FS__API_ID', 0 );
+define( 'FS__API_PUBLIC_KEY', 'your-public-key' );
+define( 'FS__API_SECRET_KEY', 'your-secret-key' );
+define( 'FS__API_LICENSE_KEY', 'your-license-key' );
+
+
+$api = new Freemius_Api(
+    FS__API_SCOPE,
+    FS__API_ID,
+    FS__API_PUBLIC_KEY,
+    FS__API_SECRET_KEY
+);
+
+$result = $api->Api( "/licenses.json", "GET", array(
+    'search' => FS__API_LICENSE_KEY,
+) );
+
+$license = null;
+
+if ( ! empty( $result->licenses ) ) {
+    echo '<pre>';
+    var_dump( $result->licenses );
+} else {
+    echo 'No licenses found';
+}


### PR DESCRIPTION
Added logic to append the query string to the $pCanonizedPath in cases where the API method is GET and $pParams is not empty. This ensures that the GET parameters are correctly passed and not lost during the API call.